### PR TITLE
deprecation notice

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('chaplean_ovh_logs');
+        $treeBuilder = new TreeBuilder('chaplean_ovh_logs');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
empty TreeBuilder() is deprecated. Anyway the whole file should probably be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chaplean/ovh-logs-bundle/3)
<!-- Reviewable:end -->
